### PR TITLE
fix(debugger): improve output when assertion fails in Brillig

### DIFF
--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -176,7 +176,7 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
                             .collect();
                         Err(OpcodeResolutionError::BrilligFunctionFailed {
                             payload: Some(ResolvedAssertionPayload::String(message)),
-                            call_stack: call_stack,
+                            call_stack,
                         })
                     }
 

--- a/acvm-repo/acvm/tests/solver.rs
+++ b/acvm-repo/acvm/tests/solver.rs
@@ -670,9 +670,9 @@ fn unsatisfied_opcode_resolved_brillig() {
     let solver_status = acvm.solve();
     assert_eq!(
         solver_status,
-        ACVMStatus::Failure(OpcodeResolutionError::BrilligFunctionFailed {
-            payload: None,
-            call_stack: vec![OpcodeLocation::Brillig { acir_index: 0, brillig_index: 3 }]
+        ACVMStatus::Failure(OpcodeResolutionError::UnsatisfiedConstrain {
+            opcode_location: ErrorLocation::Resolved(OpcodeLocation::Acir(0)),
+            payload: None
         }),
         "The first opcode is not satisfiable, expected an error indicating this"
     );


### PR DESCRIPTION
# Description
When an assertion fails on Brillig mode, the debugger fails to indicate the user where the program failed

<img width="1680" alt="image" src="https://github.com/manastech/noir/assets/13237343/255df28f-5021-43ae-bf58-0eea9133aa27">

while when running on ACIR mode it provides enough information
<img width="1680" alt="image" src="https://github.com/manastech/noir/assets/13237343/0a3579f5-5cd8-41df-bd1c-62522a454c5c">


## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

- `assert` constraints are translated as "`jump` to `trap`" if the condition is not met when running in Brillig mode
- Solution: treat `FailureReason::Trap` specifically when handling brillig vm status. Treat these failures as an `OpcodeResolutionError::UnsatisfiedConstrain` instead of an `OpcodeResolutionError::BrilligFunctionFailed`
  - By doing these, the error will be reported the same way as when running in ACIR mode

<img width="1680" alt="image" src="https://github.com/manastech/noir/assets/13237343/70828e7b-b03c-4057-b40b-9fff7ad100ab">


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
