### PR TITLE
fix(debugger): improve output when constrain fails

### DIFF
--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -176,7 +176,7 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
                             .collect();
                         Err(OpcodeResolutionError::BrilligFunctionFailed {
                             payload: Some(ResolvedAssertionPayload::String(message)),
-                            call_stack: call_stack,
+                            call_stack,
                         })
                     }
 

--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -161,9 +161,6 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
         match vm_status {
             VMStatus::Finished { .. } => Ok(BrilligSolverStatus::Finished),
             VMStatus::InProgress => Ok(BrilligSolverStatus::InProgress),
-            VMStatus::ForeignCallWait { function, inputs } => {
-                Ok(BrilligSolverStatus::ForeignCallWait(ForeignCallWaitInfo { function, inputs }))
-            }
             VMStatus::Failure { reason, call_stack } => {
                 match reason {
                     FailureReason::RuntimeError { message } => {
@@ -228,6 +225,9 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
                         })
                     }
                 }
+            }
+            VMStatus::ForeignCallWait { function, inputs } => {
+                Ok(BrilligSolverStatus::ForeignCallWait(ForeignCallWaitInfo { function, inputs }))
             }
         }
     }

--- a/acvm-repo/acvm/src/pwg/mod.rs
+++ b/acvm-repo/acvm/src/pwg/mod.rs
@@ -13,6 +13,7 @@ use acir::{
     AcirField, BlackBoxFunc,
 };
 use acvm_blackbox_solver::BlackBoxResolutionError;
+use brillig_vm::FailureReason;
 
 use self::{
     arithmetic::ExpressionSolver, blackbox::bigint::AcvmBigIntSolver, directives::solve_directives,
@@ -132,7 +133,7 @@ pub enum OpcodeResolutionError<F> {
     BrilligFunctionFailed {
         call_stack: Vec<OpcodeLocation>,
         payload: Option<ResolvedAssertionPayload<F>>,
-        found_trap: bool,
+        reason: FailureReason,
     },
     AcirMainCallAttempted {
         opcode_location: ErrorLocation,
@@ -151,8 +152,8 @@ impl<F: acir::AcirField> std::fmt::Display for OpcodeResolutionError<F> {
             OpcodeResolutionError::UnsatisfiedConstrain { .. } => write!(f, "Cannot satisfy constraint"),
             OpcodeResolutionError::IndexOutOfBounds { array_size, index, .. } => write!(f, "Index out of bounds, array has size {}, but index was {}", array_size, index),
             OpcodeResolutionError::BlackBoxFunctionFailed(func, reason) => write!(f,"Failed to solve blackbox function: {}, reason: {}", func, reason),
-            OpcodeResolutionError::BrilligFunctionFailed{found_trap: false, .. } => write!(f, "Failed to solve brillig function"),
-            OpcodeResolutionError::BrilligFunctionFailed{found_trap: true, .. } => write!(f, "Cannot satisfy constraint"),
+            OpcodeResolutionError::BrilligFunctionFailed{reason: FailureReason::Trap {.. }, .. } => write!(f, "Cannot satisfy constraint"),
+            OpcodeResolutionError::BrilligFunctionFailed{ .. } => write!(f, "Failed to solve brillig function"),
             OpcodeResolutionError::AcirMainCallAttempted{ .. } => write!(f, "Attempted to call `main` with a `Call` opcode"),
             OpcodeResolutionError::AcirCallOutputsMismatch {results_size, outputs_size, .. } => write!(f, "{} result values were provided for {} call output witnesses, most likely due to bad ACIR codegen", results_size, outputs_size),
     }

--- a/acvm-repo/acvm/tests/solver.rs
+++ b/acvm-repo/acvm/tests/solver.rs
@@ -672,7 +672,8 @@ fn unsatisfied_opcode_resolved_brillig() {
         solver_status,
         ACVMStatus::Failure(OpcodeResolutionError::BrilligFunctionFailed {
             payload: None,
-            call_stack: vec![OpcodeLocation::Brillig { acir_index: 0, brillig_index: 3 }]
+            call_stack: vec![OpcodeLocation::Brillig { acir_index: 0, brillig_index: 3 }],
+            found_trap: true,
         }),
         "The first opcode is not satisfiable, expected an error indicating this"
     );

--- a/acvm-repo/acvm/tests/solver.rs
+++ b/acvm-repo/acvm/tests/solver.rs
@@ -14,7 +14,7 @@ use acir::{
 
 use acvm::pwg::{ACVMStatus, ErrorLocation, ForeignCallWaitInfo, OpcodeResolutionError, ACVM};
 use acvm_blackbox_solver::StubbedBlackBoxSolver;
-use brillig_vm::brillig::HeapValueType;
+use brillig_vm::{brillig::HeapValueType, FailureReason};
 
 // Reenable these test cases once we move the brillig implementation of inversion down into the acvm stdlib.
 
@@ -673,7 +673,7 @@ fn unsatisfied_opcode_resolved_brillig() {
         ACVMStatus::Failure(OpcodeResolutionError::BrilligFunctionFailed {
             payload: None,
             call_stack: vec![OpcodeLocation::Brillig { acir_index: 0, brillig_index: 3 }],
-            found_trap: true,
+            reason: FailureReason::Trap { revert_data_offset: 0, revert_data_size: 0 },
         }),
         "The first opcode is not satisfiable, expected an error indicating this"
     );

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -297,7 +297,7 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> DebugContext<'a, B> {
                 self.handle_foreign_call(foreign_call)
             }
             Err(err) => {
-                if let OpcodeResolutionError::UnsatisfiedConstrain { .. } = err {
+                if let OpcodeResolutionError::BrilligFunctionFailed { found_trap: true, .. } = err {
                     // return solver ownership so brillig_solver it has the right opcode location
                     self.brillig_solver = Some(solver);
                 }

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -4,7 +4,8 @@ use acvm::acir::circuit::{Circuit, Opcode, OpcodeLocation};
 use acvm::acir::native_types::{Witness, WitnessMap};
 use acvm::brillig_vm::MemoryValue;
 use acvm::pwg::{
-    ACVMStatus, BrilligSolver, BrilligSolverStatus, ForeignCallWaitInfo, StepResult, ACVM,
+    ACVMStatus, AcirCallWaitInfo, BrilligSolver, BrilligSolverStatus, ForeignCallWaitInfo,
+    OpcodeNotSolvable, OpcodeResolutionError, StepResult, ACVM,
 };
 use acvm::{BlackBoxFunctionSolver, FieldElement};
 
@@ -295,10 +296,16 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> DebugContext<'a, B> {
                 self.brillig_solver = Some(solver);
                 self.handle_foreign_call(foreign_call)
             }
-            Err(err) => DebugCommandResult::Error(NargoError::ExecutionError(
-                // TODO: debugger does not handle multiple acir calls
-                ExecutionError::SolvingError(err, None),
-            )),
+            Err(err) => {
+                if let OpcodeResolutionError::UnsatisfiedConstrain { .. } = err {
+                    // return solver ownership so brillig_solver it has the right opcode location
+                    self.brillig_solver = Some(solver);
+                }
+                // TODO: should we return solver ownership in all Err scenarios>?
+                DebugCommandResult::Error(NargoError::ExecutionError(ExecutionError::SolvingError(
+                    err, None,
+                )))
+            }
         }
     }
 

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -1,11 +1,11 @@
 use crate::foreign_calls::DebugForeignCallExecutor;
 use acvm::acir::circuit::brillig::BrilligBytecode;
 use acvm::acir::circuit::{Circuit, Opcode, OpcodeLocation};
-use acvm::acir::native_types::{Witness, WitnessMap, WitnessStack};
+use acvm::acir::native_types::{Witness, WitnessMap};
 use acvm::brillig_vm::{FailureReason, MemoryValue};
 use acvm::pwg::{
-    ACVMStatus, AcirCallWaitInfo, BrilligSolver, BrilligSolverStatus, ForeignCallWaitInfo,
-    OpcodeNotSolvable, OpcodeResolutionError, StepResult, ACVM,
+    ACVMStatus, BrilligSolver, BrilligSolverStatus, ForeignCallWaitInfo,
+    OpcodeResolutionError, StepResult, ACVM,
 };
 use acvm::{BlackBoxFunctionSolver, FieldElement};
 

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -1,8 +1,8 @@
 use crate::foreign_calls::DebugForeignCallExecutor;
 use acvm::acir::circuit::brillig::BrilligBytecode;
 use acvm::acir::circuit::{Circuit, Opcode, OpcodeLocation};
-use acvm::acir::native_types::{Witness, WitnessMap};
-use acvm::brillig_vm::MemoryValue;
+use acvm::acir::native_types::{Witness, WitnessMap, WitnessStack};
+use acvm::brillig_vm::{FailureReason, MemoryValue};
 use acvm::pwg::{
     ACVMStatus, AcirCallWaitInfo, BrilligSolver, BrilligSolverStatus, ForeignCallWaitInfo,
     OpcodeNotSolvable, OpcodeResolutionError, StepResult, ACVM,
@@ -297,7 +297,11 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> DebugContext<'a, B> {
                 self.handle_foreign_call(foreign_call)
             }
             Err(err) => {
-                if let OpcodeResolutionError::BrilligFunctionFailed { found_trap: true, .. } = err {
+                if let OpcodeResolutionError::BrilligFunctionFailed {
+                    reason: FailureReason::Trap { .. },
+                    ..
+                } = err
+                {
                     // return solver ownership so brillig_solver it has the right opcode location
                     self.brillig_solver = Some(solver);
                 }


### PR DESCRIPTION
## Description
When an assertion fails on Brillig mode, the debugger fails to indicate the user where the program failed

<img width="1085" alt="image" src="https://github.com/manastech/noir/assets/13237343/8d92fe18-899e-4665-9601-a52ba0c64771">

while when running on ACIR mode it provides enough information 👇 
<img width="932" alt="image" src="https://github.com/manastech/noir/assets/13237343/7d7e9ef4-3655-4baf-bd3e-d7c46ec97477">

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

### Context 
`assert` constraints are translated as "jump to trap" if the condition is not met when running in Brillig mode

### Changes
 - Add a new field to `OpcodeResolutionError::BrilligFunctionFailed` to track whether the function failed due to a trap opcode or not
 - Modify `BrilligFunctionFailed` `Display` implementation when function failed due to a Trap 
   - for doing this I had to remove the usage of `Error` derive macro, to have a conditional message
   - I decided it was better to have this way rather than just having a new type only for the convenience of the macro

<img width="995" alt="image" src="https://github.com/manastech/noir/assets/13237343/0b526806-203a-4cef-b115-f5f61aae58fd">

### Observations
 - `TODO:` should we return solver ownership in all Err scenarios>?

## Documentation

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
