### PR TITLE
fix: add new `BrilligFunctionUnsatisfiedConstrain` resolution error variant

### DIFF
--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -171,7 +171,7 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
                     .collect();
                 let payload = self.extract_failure_payload(&reason);
 
-                let resolution_error = |payload, call_stack: Vec<OpcodeLocation>| match &reason {
+                let resolution_error = |payload, call_stack| match &reason {
                     FailureReason::RuntimeError { .. } => {
                         OpcodeResolutionError::BrilligFunctionFailed { payload, call_stack }
                     }

--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -161,9 +161,6 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
         match vm_status {
             VMStatus::Finished { .. } => Ok(BrilligSolverStatus::Finished),
             VMStatus::InProgress => Ok(BrilligSolverStatus::InProgress),
-            VMStatus::ForeignCallWait { function, inputs } => {
-                Ok(BrilligSolverStatus::ForeignCallWait(ForeignCallWaitInfo { function, inputs }))
-            }
             VMStatus::Failure { reason, call_stack } => {
                 let call_stack = call_stack
                     .iter()
@@ -228,6 +225,9 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
                         })
                     }
                 }
+            }
+            VMStatus::ForeignCallWait { function, inputs } => {
+                Ok(BrilligSolverStatus::ForeignCallWait(ForeignCallWaitInfo { function, inputs }))
             }
         }
     }

--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -176,7 +176,7 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
                             .collect();
                         Err(OpcodeResolutionError::BrilligFunctionFailed {
                             payload: Some(ResolvedAssertionPayload::String(message)),
-                            call_stack: call_stack,
+                            call_stack,
                         })
                     }
 

--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -165,15 +165,15 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
                 Ok(BrilligSolverStatus::ForeignCallWait(ForeignCallWaitInfo { function, inputs }))
             }
             VMStatus::Failure { reason, call_stack } => {
+                let call_stack = call_stack
+                    .iter()
+                    .map(|brillig_index| OpcodeLocation::Brillig {
+                        acir_index: self.acir_index,
+                        brillig_index: *brillig_index,
+                    })
+                    .collect();
                 match reason {
                     FailureReason::RuntimeError { message } => {
-                        let call_stack = call_stack
-                            .iter()
-                            .map(|brillig_index| OpcodeLocation::Brillig {
-                                acir_index: self.acir_index,
-                                brillig_index: *brillig_index,
-                            })
-                            .collect();
                         Err(OpcodeResolutionError::BrilligFunctionFailed {
                             payload: Some(ResolvedAssertionPayload::String(message)),
                             call_stack,
@@ -222,9 +222,9 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
                             }
                         };
 
-                        Err(OpcodeResolutionError::UnsatisfiedConstrain {
-                            opcode_location: super::ErrorLocation::Unresolved,
+                        Err(OpcodeResolutionError::BrilligFunctionUnsatisfiedConstrain {
                             payload,
+                            call_stack,
                         })
                     }
                 }

--- a/acvm-repo/acvm/src/pwg/mod.rs
+++ b/acvm-repo/acvm/src/pwg/mod.rs
@@ -134,6 +134,11 @@ pub enum OpcodeResolutionError<F> {
         call_stack: Vec<OpcodeLocation>,
         payload: Option<ResolvedAssertionPayload<F>>,
     },
+    #[error("Cannot satisfy constraint")]
+    BrilligFunctionUnsatisfiedConstrain {
+        call_stack: Vec<OpcodeLocation>,
+        payload: Option<ResolvedAssertionPayload<F>>,
+    },
     #[error("Attempted to call `main` with a `Call` opcode")]
     AcirMainCallAttempted { opcode_location: ErrorLocation },
     #[error("{results_size:?} result values were provided for {outputs_size:?} call output witnesses, most likely due to bad ACIR codegen")]
@@ -501,7 +506,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> ACVM<'a, F, B> {
 
     fn map_brillig_error(&self, mut err: OpcodeResolutionError<F>) -> OpcodeResolutionError<F> {
         match &mut err {
-            OpcodeResolutionError::BrilligFunctionFailed { call_stack, payload } => {
+            OpcodeResolutionError::BrilligFunctionUnsatisfiedConstrain { call_stack, payload } => {
                 // Some brillig errors have static strings as payloads, we can resolve them here
                 let last_location =
                     call_stack.last().expect("Call stacks should have at least one item");

--- a/acvm-repo/acvm/tests/solver.rs
+++ b/acvm-repo/acvm/tests/solver.rs
@@ -670,9 +670,9 @@ fn unsatisfied_opcode_resolved_brillig() {
     let solver_status = acvm.solve();
     assert_eq!(
         solver_status,
-        ACVMStatus::Failure(OpcodeResolutionError::BrilligFunctionFailed {
-            payload: None,
-            call_stack: vec![OpcodeLocation::Brillig { acir_index: 0, brillig_index: 3 }]
+        ACVMStatus::Failure(OpcodeResolutionError::UnsatisfiedConstrain {
+            opcode_location: ErrorLocation::Resolved(OpcodeLocation::Acir(0)),
+            payload: None
         }),
         "The first opcode is not satisfiable, expected an error indicating this"
     );

--- a/acvm-repo/acvm/tests/solver.rs
+++ b/acvm-repo/acvm/tests/solver.rs
@@ -670,9 +670,9 @@ fn unsatisfied_opcode_resolved_brillig() {
     let solver_status = acvm.solve();
     assert_eq!(
         solver_status,
-        ACVMStatus::Failure(OpcodeResolutionError::UnsatisfiedConstrain {
-            opcode_location: ErrorLocation::Resolved(OpcodeLocation::Acir(0)),
-            payload: None
+        ACVMStatus::Failure(OpcodeResolutionError::BrilligFunctionUnsatisfiedConstrain {
+            payload: None,
+            call_stack: vec![OpcodeLocation::Brillig { acir_index: 0, brillig_index: 3 }]
         }),
         "The first opcode is not satisfiable, expected an error indicating this"
     );

--- a/acvm-repo/acvm_js/src/execute.rs
+++ b/acvm-repo/acvm_js/src/execute.rs
@@ -200,9 +200,11 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> ProgramExecutor<'a, B> {
                                 opcode_location: ErrorLocation::Resolved(opcode_location),
                                 ..
                             } => Some(vec![*opcode_location]),
-                            OpcodeResolutionError::BrilligFunctionFailed { call_stack, .. } => {
-                                Some(call_stack.clone())
-                            }
+                            OpcodeResolutionError::BrilligFunctionFailed { call_stack, .. }
+                            | OpcodeResolutionError::BrilligFunctionUnsatisfiedConstrain {
+                                call_stack,
+                                ..
+                            } => Some(call_stack.clone()),
                             _ => None,
                         };
                         // If the failed opcode has an assertion message, integrate it into the error message for backwards compatibility.
@@ -213,6 +215,10 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> ProgramExecutor<'a, B> {
                                 ..
                             }
                             | OpcodeResolutionError::BrilligFunctionFailed {
+                                payload: Some(payload),
+                                ..
+                            }
+                            | OpcodeResolutionError::BrilligFunctionUnsatisfiedConstrain {
                                 payload: Some(payload),
                                 ..
                             } => match payload {

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -4,8 +4,8 @@ use acvm::acir::circuit::{Circuit, Opcode, OpcodeLocation};
 use acvm::acir::native_types::{Witness, WitnessMap};
 use acvm::brillig_vm::MemoryValue;
 use acvm::pwg::{
-    ACVMStatus, BrilligSolver, BrilligSolverStatus, ForeignCallWaitInfo,
-    OpcodeResolutionError, StepResult, ACVM,
+    ACVMStatus, BrilligSolver, BrilligSolverStatus, ForeignCallWaitInfo, OpcodeResolutionError,
+    StepResult, ACVM,
 };
 use acvm::{BlackBoxFunctionSolver, FieldElement};
 

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -297,7 +297,7 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> DebugContext<'a, B> {
                 self.handle_foreign_call(foreign_call)
             }
             Err(err) => {
-                if let OpcodeResolutionError::UnsatisfiedConstrain { .. } = err {
+                if let OpcodeResolutionError::BrilligFunctionUnsatisfiedConstrain { .. } = err {
                     // return solver ownership so brillig_solver it has the right opcode location
                     self.brillig_solver = Some(solver);
                 }

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -4,7 +4,8 @@ use acvm::acir::circuit::{Circuit, Opcode, OpcodeLocation};
 use acvm::acir::native_types::{Witness, WitnessMap};
 use acvm::brillig_vm::MemoryValue;
 use acvm::pwg::{
-    ACVMStatus, BrilligSolver, BrilligSolverStatus, ForeignCallWaitInfo, StepResult, ACVM,
+    ACVMStatus, BrilligSolver, BrilligSolverStatus, ForeignCallWaitInfo,
+    OpcodeResolutionError, StepResult, ACVM,
 };
 use acvm::{BlackBoxFunctionSolver, FieldElement};
 
@@ -295,10 +296,16 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> DebugContext<'a, B> {
                 self.brillig_solver = Some(solver);
                 self.handle_foreign_call(foreign_call)
             }
-            Err(err) => DebugCommandResult::Error(NargoError::ExecutionError(
-                // TODO: debugger does not handle multiple acir calls
-                ExecutionError::SolvingError(err, None),
-            )),
+            Err(err) => {
+                if let OpcodeResolutionError::UnsatisfiedConstrain { .. } = err {
+                    // return solver ownership so brillig_solver it has the right opcode location
+                    self.brillig_solver = Some(solver);
+                }
+                // TODO: should we return solver ownership in all Err scenarios>?
+                DebugCommandResult::Error(NargoError::ExecutionError(ExecutionError::SolvingError(
+                    err, None,
+                )))
+            }
         }
     }
 

--- a/tooling/nargo/src/errors.rs
+++ b/tooling/nargo/src/errors.rs
@@ -84,6 +84,7 @@ impl<F: AcirField> NargoError<F> {
                 | OpcodeResolutionError::UnsatisfiedConstrain { .. }
                 | OpcodeResolutionError::AcirMainCallAttempted { .. }
                 | OpcodeResolutionError::BrilligFunctionFailed { .. }
+                | OpcodeResolutionError::BrilligFunctionUnsatisfiedConstrain { .. }
                 | OpcodeResolutionError::AcirCallOutputsMismatch { .. } => None,
                 OpcodeResolutionError::BlackBoxFunctionFailed(_, reason) => {
                     Some(reason.to_string())
@@ -110,6 +111,10 @@ fn extract_locations_from_error<F: AcirField>(
     let mut opcode_locations = match error {
         ExecutionError::SolvingError(
             OpcodeResolutionError::BrilligFunctionFailed { .. },
+            acir_call_stack,
+        )
+        | ExecutionError::SolvingError(
+            OpcodeResolutionError::BrilligFunctionUnsatisfiedConstrain { .. },
             acir_call_stack,
         ) => acir_call_stack.clone(),
         ExecutionError::AssertionFailed(_, call_stack) => Some(call_stack.clone()),

--- a/tooling/nargo/src/ops/execute.rs
+++ b/tooling/nargo/src/ops/execute.rs
@@ -97,7 +97,11 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>, E: ForeignCallExecutor<F>>
                             self.call_stack.push(resolved_location);
                             Some(self.call_stack.clone())
                         }
-                        OpcodeResolutionError::BrilligFunctionFailed { call_stack, .. } => {
+                        OpcodeResolutionError::BrilligFunctionFailed { call_stack, .. }
+                        | OpcodeResolutionError::BrilligFunctionUnsatisfiedConstrain {
+                            call_stack,
+                            ..
+                        } => {
                             let brillig_call_stack =
                                 call_stack.iter().map(|location| ResolvedOpcodeLocation {
                                     acir_function_index: self.current_function_index,
@@ -111,6 +115,10 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>, E: ForeignCallExecutor<F>>
 
                     let assertion_payload: Option<ResolvedAssertionPayload<F>> = match &error {
                         OpcodeResolutionError::BrilligFunctionFailed { payload, .. }
+                        | OpcodeResolutionError::BrilligFunctionUnsatisfiedConstrain {
+                            payload,
+                            ..
+                        }
                         | OpcodeResolutionError::UnsatisfiedConstrain { payload, .. } => {
                             payload.clone()
                         }


### PR DESCRIPTION
this is an alternate solution to #5 
it has more effects outside the scope of the debugger, but it feels more accurate

## Description
When an assertion fails on Brillig mode, the debugger fails to indicate the user where the program failed

<img width="1085" alt="image" src="https://github.com/manastech/noir/assets/13237343/8d92fe18-899e-4665-9601-a52ba0c64771">

while when running on ACIR mode it provides enough information 👇 
<img width="932" alt="image" src="https://github.com/manastech/noir/assets/13237343/7d7e9ef4-3655-4baf-bd3e-d7c46ec97477">


## Summary

### Context 
`assert` constraints are translated as "jump to trap" if the condition is not met when running in Brillig mode

### Changes
 - Add a new variant `OpcodeResolutionError::BrilligFunctionUnsatisfiedConstrain` to represent failed constraints on Brillig
 - Return this new error when brillig code fails due to a `Trap` failure
 - Return the ownership of the solver to brillig context when the debugger fails due to this new resolution error so that the the last opcode is known for showing the error
 - Changed the variant checking on `ACVM.map_brillig_error` from `OpcodeResolutionError::BrilligFunctionFailed` to `OpcodeResolutionError::BrilligFunctionUnsatisfiedConstrain` since assertion errors will now fail with the latter
 - Add new branch on related match expressions to treat the new variant the same way as `BrilligFunctionFailed` for the other cases

<img width="914" alt="image" src="https://github.com/noir-lang/noir/assets/13237343/8faa8da7-c4a9-4626-b8a7-a91311cb364f">

### Observations
 - `TODO:` should we return the solver ownership to the brillig context in all Err scenarios>?

## Documentation

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

